### PR TITLE
Fix/wasm wgpu uniform padding

### DIFF
--- a/assets/shaders/background/nebulae.wgsl
+++ b/assets/shaders/background/nebulae.wgsl
@@ -7,6 +7,7 @@ struct BackgroundNebulaeMaterial {
     pixels: f32,
     uv_correct: vec2<f32>,
     background_color: vec4<f32>,
+    _wasm_padding: vec2<f32>,
 }
 
 @group(2) @binding(0) var<uniform> bg_nebulae: BackgroundNebulaeMaterial;

--- a/assets/shaders/background/stars.wgsl
+++ b/assets/shaders/background/stars.wgsl
@@ -6,6 +6,7 @@ struct BackgroundStarsMaterial {
     seed: f32,
     pixels: f32,
     uv_correct: vec2<f32>,
+    _wasm_padding: vec2<f32>,
 }
 
 @group(2) @binding(0) var<uniform> bg_stars: BackgroundStarsMaterial;

--- a/assets/shaders/planet/clouds.wgsl
+++ b/assets/shaders/planet/clouds.wgsl
@@ -12,6 +12,7 @@ struct CloudsMaterial {
     outline_color: vec4<f32>,
     shadow_color: vec4<f32>,
     shadow_outline_color: vec4<f32>,
+	_wasm_padding: vec3<f32>,
 }
 
 @group(2) @binding(1) var<uniform> pm_clouds: CloudsMaterial;

--- a/assets/shaders/planet/craters.wgsl
+++ b/assets/shaders/planet/craters.wgsl
@@ -6,6 +6,7 @@ struct CratersMaterial {
     light_border: f32,
     color1: vec4<f32>,
     color2: vec4<f32>,
+	_wasm_padding: vec3<f32>,
 }
 
 @group(2) @binding(1) var<uniform> pm_craters: CratersMaterial;

--- a/assets/shaders/planet/dry_terrain.wgsl
+++ b/assets/shaders/planet/dry_terrain.wgsl
@@ -6,6 +6,7 @@ struct DryTerrainMaterial {
     dither_size: f32,
     light_distance_1: f32,
     light_distance_2: f32,
+    _wasm_padding: f32,
 }
 
 @group(2) @binding(1) var<uniform> pm_dry: DryTerrainMaterial;

--- a/assets/shaders/planet/gas_layers.wgsl
+++ b/assets/shaders/planet/gas_layers.wgsl
@@ -4,6 +4,7 @@
     
 struct GasLayersMaterial {
     bands: f32,
+    _wasm_padding: vec3<f32>,
 }
 
 @group(2) @binding(1) var<uniform> pm_gas_layers: GasLayersMaterial;

--- a/assets/shaders/planet/lakes.wgsl
+++ b/assets/shaders/planet/lakes.wgsl
@@ -9,6 +9,7 @@ struct LakesMaterial {
     color1: vec4<f32>,
     color2: vec4<f32>,
     color3: vec4<f32>,
+	_wasm_padding: f32,
 }
 
 @group(2) @binding(1) var<uniform> pm_lakes: LakesMaterial;

--- a/assets/shaders/planet/landmasses.wgsl
+++ b/assets/shaders/planet/landmasses.wgsl
@@ -10,6 +10,7 @@ struct LandmassesMaterial {
     color2: vec4<f32>,
     color3: vec4<f32>,
     color4: vec4<f32>,
+    _wasm_padding: f32,
 }
 
 @group(2) @binding(1) var<uniform> pm_under: LandmassesMaterial;

--- a/assets/shaders/planet/ring.wgsl
+++ b/assets/shaders/planet/ring.wgsl
@@ -6,6 +6,7 @@ struct RingMaterial {
     ring_width: f32,
     ring_perspective: f32,
     scale_rel_to_planet: f32
+    _wasm_padding: f32
 }
 
 @group(2) @binding(1) var<uniform> pm_ring: RingMaterial;

--- a/assets/shaders/planet/ring.wgsl
+++ b/assets/shaders/planet/ring.wgsl
@@ -5,8 +5,8 @@
 struct RingMaterial {
     ring_width: f32,
     ring_perspective: f32,
-    scale_rel_to_planet: f32
-    _wasm_padding: f32
+    scale_rel_to_planet: f32,
+    _wasm_padding: f32,
 }
 
 @group(2) @binding(1) var<uniform> pm_ring: RingMaterial;

--- a/assets/shaders/planet/under.wgsl
+++ b/assets/shaders/planet/under.wgsl
@@ -9,6 +9,7 @@ struct UnderMaterial {
     color1: vec4<f32>,
     color2: vec4<f32>,
     color3: vec4<f32>,
+    _wasm_padding: f32,
 }
 
 @group(2) @binding(1) var<uniform> pm_under: UnderMaterial;

--- a/src/core/background.rs
+++ b/src/core/background.rs
@@ -33,6 +33,8 @@ struct StarsMaterial {
     pub pixels: f32,
     #[uniform(0)]
     pub uv_correct: Vec2,
+    #[uniform(0)]
+    _wasm_padding: Vec2,
     #[texture(1)]
     #[sampler(2)]
     colorscheme_texture: Option<Handle<Image>>,
@@ -58,6 +60,8 @@ struct NebulaeMaterial {
     pub uv_correct: Vec2,
     #[uniform(0)]
     pub background_color: LinearRgba,
+    #[uniform(0)]
+    _wasm_padding: Vec2,
     #[texture(1)]
     #[sampler(2)]
     colorscheme_texture: Option<Handle<Image>>,
@@ -96,6 +100,7 @@ fn setup(
         pixels: 500.0,
         uv_correct: Vec2::ONE,
         colorscheme_texture: Some(colorscheme.clone_weak()),
+        _wasm_padding: Vec2::default(),
     });
 
     let nebulae = nebulae_materials.add(NebulaeMaterial {
@@ -106,6 +111,7 @@ fn setup(
         uv_correct: Vec2::ONE,
         background_color: Srgba::hex("#171711").unwrap().into(),
         colorscheme_texture: Some(colorscheme),
+        _wasm_padding: Vec2::default(),
     });
 
     commands.spawn((

--- a/src/entities/planet/materials/clouds.rs
+++ b/src/entities/planet/materials/clouds.rs
@@ -30,6 +30,8 @@ pub struct CloudsMaterial {
     pub shadow_color: LinearRgba,
     #[uniform(1)]
     pub shadow_outline_color: LinearRgba,
+    #[uniform(1)]
+    _wasm_padding: Vec3,
 }
 
 #[derive(Component, serde::Deserialize, Clone)]
@@ -78,6 +80,7 @@ impl PlanetMaterial for CloudsMaterial {
             outline_color: Srgba::hex(&config.palette[1]).unwrap().into(),
             shadow_color: Srgba::hex(&config.palette[2]).unwrap().into(),
             shadow_outline_color: Srgba::hex(&config.palette[3]).unwrap().into(),
+            _wasm_padding: Vec3::default(),
         }
     }
 }

--- a/src/entities/planet/materials/craters.rs
+++ b/src/entities/planet/materials/craters.rs
@@ -18,6 +18,8 @@ pub struct CratersMaterial {
     pub color1: LinearRgba,
     #[uniform(1)]
     pub color2: LinearRgba,
+    #[uniform(1)]
+    _wasm_padding: Vec3,
 }
 
 #[derive(Component, serde::Deserialize, Clone)]
@@ -54,6 +56,7 @@ impl PlanetMaterial for CratersMaterial {
             light_border: config.light_border,
             color1: Srgba::hex(&config.palette[0]).unwrap().into(),
             color2: Srgba::hex(&config.palette[1]).unwrap().into(),
+            _wasm_padding: Vec3::default(),
         }
     }
 }

--- a/src/entities/planet/materials/dry_terrain.rs
+++ b/src/entities/planet/materials/dry_terrain.rs
@@ -18,6 +18,8 @@ pub struct DryTerrainMaterial {
     pub light_distance_1: f32,
     #[uniform(1)]
     pub light_distance_2: f32,
+    #[uniform(1)]
+    _wasm_padding: f32,
     #[texture(2)]
     #[sampler(3)]
     color_texture: Option<Handle<Image>>,
@@ -70,6 +72,7 @@ impl PlanetMaterial for DryTerrainMaterial {
             light_distance_1: config.light_distance_1,
             light_distance_2: config.light_distance_2,
             color_texture: Some(images.add(gradient)),
+            _wasm_padding: 0.0,
         }
     }
 }

--- a/src/entities/planet/materials/gas_layers.rs
+++ b/src/entities/planet/materials/gas_layers.rs
@@ -14,6 +14,8 @@ pub struct GasLayersMaterial {
     pub common: super::CommonMaterial,
     #[uniform(1)]
     pub bands: f32,
+    #[uniform(1)]
+    _wasm_padding: Vec3,
     #[texture(2)]
     #[sampler(3)]
     colorscheme_texture: Option<Handle<Image>>,
@@ -77,6 +79,7 @@ impl PlanetMaterial for GasLayersMaterial {
             bands: config.bands,
             colorscheme_texture: Some(images.add(gradient)),
             darkcolorscheme_texture: Some(images.add(dark_gradient)),
+            _wasm_padding: Vec3::default(),
         }
     }
 }

--- a/src/entities/planet/materials/lakes.rs
+++ b/src/entities/planet/materials/lakes.rs
@@ -24,6 +24,8 @@ pub struct LakesMaterial {
     pub color2: LinearRgba,
     #[uniform(1)]
     pub color3: LinearRgba,
+    #[uniform(1)]
+    _wasm_padding: f32,
 }
 
 #[derive(serde::Deserialize, Component, Clone)]
@@ -65,6 +67,7 @@ impl PlanetMaterial for LakesMaterial {
             color1: Srgba::hex(&config.palette[0]).unwrap().into(),
             color2: Srgba::hex(&config.palette[1]).unwrap().into(),
             color3: Srgba::hex(&config.palette[2]).unwrap().into(),
+            _wasm_padding: 0.0,
         }
     }
 }

--- a/src/entities/planet/materials/landmasses.rs
+++ b/src/entities/planet/materials/landmasses.rs
@@ -26,6 +26,8 @@ pub struct LandmassesMaterial {
     pub color3: LinearRgba,
     #[uniform(1)]
     pub color4: LinearRgba,
+    #[uniform(1)]
+    _wasm_padding: f32,
 }
 
 #[derive(serde::Deserialize, Component, Clone)]
@@ -68,6 +70,7 @@ impl PlanetMaterial for LandmassesMaterial {
             color2: Srgba::hex(&config.palette[1]).unwrap().into(),
             color3: Srgba::hex(&config.palette[2]).unwrap().into(),
             color4: Srgba::hex(&config.palette[3]).unwrap().into(),
+            _wasm_padding: 0.0,
         }
     }
 }

--- a/src/entities/planet/materials/ring.rs
+++ b/src/entities/planet/materials/ring.rs
@@ -18,6 +18,8 @@ pub struct RingMaterial {
     pub ring_perspective: f32,
     #[uniform(1)]
     pub scale_rel_to_planet: f32,
+    #[uniform(1)]
+    _wasm_padding: f32,
     #[texture(2)]
     #[sampler(3)]
     colorscheme_texture: Option<Handle<Image>>,
@@ -87,6 +89,7 @@ impl PlanetMaterial for RingMaterial {
             scale_rel_to_planet: config.scale_rel_to_planet,
             colorscheme_texture: Some(images.add(gradient)),
             darkcolorscheme_texture: Some(images.add(dark_gradient)),
+            _wasm_padding: 0.0,
         }
     }
 }

--- a/src/entities/planet/materials/under.rs
+++ b/src/entities/planet/materials/under.rs
@@ -24,6 +24,8 @@ pub struct UnderMaterial {
     pub color2: LinearRgba,
     #[uniform(1)]
     pub color3: LinearRgba,
+    #[uniform(1)]
+    _wasm_padding: f32,
 }
 
 #[derive(Component, serde::Deserialize, Clone)]
@@ -65,6 +67,7 @@ impl PlanetMaterial for UnderMaterial {
             color1: Srgba::hex(&config.palette[0]).unwrap().into(),
             color2: Srgba::hex(&config.palette[1]).unwrap().into(),
             color3: Srgba::hex(&config.palette[2]).unwrap().into(),
+            _wasm_padding: 0.0,
         }
     }
 }


### PR DESCRIPTION
Add `_wasm_padding` uniform to all shader bindings in order to fix `BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED` wgpu error in WASM builds.

For more detail see https://github.com/bevyengine/bevy/issues/5393
