### PR TITLE
Build/dev tools feature

### DIFF
--- a/src/core/worldgen.rs
+++ b/src/core/worldgen.rs
@@ -20,7 +20,7 @@ impl Plugin for WorldgenPlugin {
                 Update,
                 (
                     handle_genworld_event,
-                    #[cfg(debug_assertions)]
+                    #[cfg(feature = "dev_tools")]
                     handle_config_reload.run_if(resource_exists::<crate::network::SessionSeed>),
                 ),
             );
@@ -120,7 +120,7 @@ fn handle_genworld_event(
 }
 
 /// Re-generates world on config changes. Will cause desyncs
-#[cfg(debug_assertions)]
+#[cfg(feature = "dev_tools")]
 fn handle_config_reload(
     mut commands: Commands,
     mut events: EventReader<AssetEvent<WorldgenConfig>>,

--- a/src/entities/planet/mod.rs
+++ b/src/entities/planet/mod.rs
@@ -75,7 +75,7 @@ impl Plugin for PlanetPlugin {
                 (
                     handle_spawn_planet_event,
                     spawn_config_layers,
-                    #[cfg(debug_assertions)]
+                    #[cfg(feature = "dev_tools")]
                     handle_config_reload,
                 ),
             );
@@ -214,7 +214,7 @@ fn spawn_config_layers(
     }
 }
 
-#[cfg(debug_assertions)]
+#[cfg(feature = "dev_tools")]
 fn handle_config_reload(
     mut commands: Commands,
     mut events: EventReader<AssetEvent<PlanetsConfig>>,

--- a/src/entities/player/skin.rs
+++ b/src/entities/player/skin.rs
@@ -59,7 +59,7 @@ impl Plugin for SkinPlugin {
                 Update,
                 (
                     load_skin_on_player,
-                    #[cfg(debug_assertions)]
+                    #[cfg(feature = "dev_tools")]
                     handle_config_reload,
                 ),
             );
@@ -124,7 +124,7 @@ fn load_skin_on_player(
     }
 }
 
-#[cfg(debug_assertions)]
+#[cfg(feature = "dev_tools")]
 fn handle_config_reload(
     mut commands: Commands,
     mut events: EventReader<AssetEvent<SkinsConfig>>,

--- a/src/entities/player/weapon/mod.rs
+++ b/src/entities/player/weapon/mod.rs
@@ -38,7 +38,7 @@ impl Plugin for WeaponPlugin {
             .add_systems(
                 Update,
                 (
-                    #[cfg(debug_assertions)]
+                    #[cfg(feature = "dev_tools")]
                     handle_config_reload,
                     (add_stats_component, add_sprite)
                         .before(PhysicsSet::Player)
@@ -187,7 +187,7 @@ fn fire_weapon_system(
     }
 }
 
-#[cfg(debug_assertions)]
+#[cfg(feature = "dev_tools")]
 fn handle_config_reload(
     mut commands: Commands,
     mut events: EventReader<AssetEvent<config::WeaponsConfig>>,

--- a/src/entities/projectile/mod.rs
+++ b/src/entities/projectile/mod.rs
@@ -37,7 +37,7 @@ impl Plugin for ProjectilePlugin {
             .add_systems(
                 Update,
                 (
-                    #[cfg(debug_assertions)]
+                    #[cfg(feature = "dev_tools")]
                     handle_config_reload,
                     add_sprite,
                     rotate_sprite,
@@ -141,7 +141,7 @@ fn check_collisions(
     }
 }
 
-#[cfg(debug_assertions)]
+#[cfg(feature = "dev_tools")]
 fn handle_config_reload(
     mut commands: Commands,
     mut events: EventReader<AssetEvent<config::ProjectilesConfig>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 #[cfg(feature = "embedded_assets")]
 use bevy_embedded_assets::EmbeddedAssetPlugin;
-#[cfg(debug_assertions)]
+#[cfg(feature = "dev_tools")]
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use clap::Parser;
 
@@ -59,7 +59,7 @@ fn main() {
     .init_state::<GameState>()
     .insert_resource(args);
 
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "dev_tools")]
     app.add_plugins(WorldInspectorPlugin::new());
 
     app.run();

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -140,8 +140,12 @@ fn wait_start_match(
 
     let mut session_builder = ggrs::SessionBuilder::<SessionConfig>::new()
         .with_num_players(args.players)
-        .with_desync_detection_mode(ggrs::DesyncDetection::On { interval: 4 })
         .with_input_delay(2);
+
+    if cfg!(feature = "dev_tools") {
+        session_builder =
+            session_builder.with_desync_detection_mode(ggrs::DesyncDetection::On { interval: 4 });
+    }
 
     for (i, player) in players.into_iter().enumerate() {
         session_builder = session_builder


### PR DESCRIPTION
Fix some inconsistencies with `cfg(debug_assertions)` only code blocks by using`cfg(feature = "dev_tools")` crate feature flag instead.
Also disable desync detection when `dev_tools` crate feature flag is disabled