### PR TITLE
Chore/self hosted turn

### DIFF
--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -96,8 +96,8 @@ fn start_matchbox_socket(mut commands: Commands, args: Res<crate::Args>) {
         .add_unreliable_channel()
         .ice_server(RtcIceServerConfig {
             urls: vec!["turn:gasdev.fr:3478".to_string()],
-            username: Some("".to_string()), // Fixes `ErrNoTurnCredentials`
-            credential: Some("".to_string()), // Same
+            username: Some("default".to_string()), // Fixes `ErrNoTurnCredentials`
+            credential: Some("default".to_string()), // Same
         });
     commands.insert_resource(MatchboxSocket::from(builder));
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use bevy_ggrs::*;
-use bevy_matchbox::prelude::*;
+use bevy_matchbox::{matchbox_socket::RtcIceServerConfig, prelude::*};
 use inputs::NetworkInputs;
 use rand::Rng as _;
 
@@ -92,7 +92,14 @@ fn start_matchbox_socket(mut commands: Commands, args: Res<crate::Args>) {
         args.players
     );
     info!("connecting to matchbox server: {room_url}");
-    commands.insert_resource(MatchboxSocket::new_unreliable(room_url));
+    let builder = WebRtcSocketBuilder::new(room_url)
+        .add_unreliable_channel()
+        .ice_server(RtcIceServerConfig {
+            urls: vec!["turn:gasdev.fr:3478".to_string()],
+            username: Some("".to_string()), // Fixes `ErrNoTurnCredentials`
+            credential: Some("".to_string()), // Same
+        });
+    commands.insert_resource(MatchboxSocket::from(builder));
 }
 
 fn wait_for_players(


### PR DESCRIPTION
Now using self hosted [turn-rs](https://github.com/mycrl/turn-rs) server hosted at gasdev.fr for [Traversal Using Relays around NAT](https://en.wikipedia.org/wiki/Traversal_Using_Relays_around_NAT)