### PR TITLE
Feat/player death

### DIFF
--- a/src/entities/player/weapon/mod.rs
+++ b/src/entities/player/weapon/mod.rs
@@ -71,7 +71,7 @@ impl Plugin for WeaponPlugin {
             .add_systems(
                 GgrsSchedule,
                 (
-                    add_physical_components,
+                    add_weapon_components,
                     tick_weapon_timers,
                     fire_weapon_system,
                 )
@@ -82,7 +82,7 @@ impl Plugin for WeaponPlugin {
     }
 }
 
-fn add_physical_components(
+fn add_weapon_components(
     mut commands: Commands,
     query: Query<(Entity, &WeaponType), Without<WeaponStats>>,
     assets: Res<WeaponsConfigAssets>,
@@ -103,7 +103,7 @@ fn add_physical_components(
                 cooldown_timer: Timer::new(weapon_stats.cooldown, TimerMode::Once),
                 reload_timer: Timer::new(weapon_stats.reload_time, TimerMode::Once),
             });
-            //commands.entity(weapon_entity).insert(WeaponMode::Idle);
+            commands.entity(weapon_entity).insert(WeaponMode::Idle);
             commands.entity(weapon_entity).insert(weapon_stats.clone());
         }
     }

--- a/src/level/limit.rs
+++ b/src/level/limit.rs
@@ -89,7 +89,6 @@ pub fn handle_player_death(
         // Refresh weapons
         let arsenal = query.get(*player)?;
         for (_, weapon) in arsenal.0.iter() {
-            warn!("Removing weapon stats!");
             commands.entity(*weapon).remove::<WeaponStats>();
         }
     }


### PR DESCRIPTION
I could decouple `add_weapon_components` into `add_stats` run on `Update` and `add_state` run using  `Ggrshedule` if you want.

Resolves #102 