### PR TITLE
Fix/issue 110

### DIFF
--- a/src/core/inputs.rs
+++ b/src/core/inputs.rs
@@ -33,7 +33,7 @@ pub enum PlayerAction {
 pub enum InputSet {
     /// Where we mutate the PlayerActionState to apply custom input methods
     Update,
-    /// Final step were inputs are serialized and sent over the network
+    /// Final step where inputs are serialized and sent over the network
     Serialize,
 }
 

--- a/src/core/inputs.rs
+++ b/src/core/inputs.rs
@@ -31,7 +31,7 @@ pub enum PlayerAction {
 
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum InputSet {
-    /// Were we mutate the PlayerActionState to apply custom input methods
+    /// Where we mutate the PlayerActionState to apply custom input methods
     Update,
     /// Final step were inputs are serialized and sent over the network
     Serialize,

--- a/src/core/inputs.rs
+++ b/src/core/inputs.rs
@@ -47,7 +47,7 @@ fn update_local_pointer_direction(
     let (camera, view) = query_view.single()?;
     if let Some(world_position) = window
         .cursor_position()
-        .map(|cursor| camera.viewport_to_world_2d(view, cursor).unwrap())
+        .and_then(|cursor| camera.viewport_to_world_2d(view, cursor).ok())
     {
         for (_, player_world_pos, mut action_state) in
             player_query.iter_mut().filter(|(player, _, action)| {

--- a/src/core/inputs.rs
+++ b/src/core/inputs.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_ggrs::LocalPlayers;
+use bevy_ggrs::{LocalPlayers, ReadInputs};
 use leafwing_input_manager::prelude::*;
 
 use crate::entities::player::Player;
@@ -29,11 +29,23 @@ pub enum PlayerAction {
     RopeRetract,
 }
 
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub enum InputSet {
+    /// Were we mutate the PlayerActionState to apply custom input methods
+    Update,
+    /// Final step were inputs are serialized and sent over the network
+    Serialize,
+}
+
 pub struct InputsPlugin;
 impl Plugin for InputsPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(InputManagerPlugin::<PlayerAction>::default())
-            .add_systems(Update, update_local_pointer_direction);
+        app.configure_sets(ReadInputs, (InputSet::Update, InputSet::Serialize).chain())
+            .add_plugins(InputManagerPlugin::<PlayerAction>::default())
+            .add_systems(
+                ReadInputs,
+                update_local_pointer_direction.in_set(InputSet::Update),
+            );
     }
 }
 

--- a/src/network/inputs.rs
+++ b/src/network/inputs.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use crate::{
     core::{
-        inputs::{PlayerAction, PlayerActionState},
+        inputs::{InputSet, PlayerAction, PlayerActionState},
         physics::PhysicsSet,
     },
     entities::player::Player,
@@ -42,10 +42,11 @@ pub struct AlwaysEqWrapper<T>(T);
 pub struct NetworkInputsPlugin;
 impl Plugin for NetworkInputsPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(ReadInputs, read_local_inputs).add_systems(
-            GgrsSchedule,
-            update_remote_inputs.before(PhysicsSet::Player),
-        );
+        app.add_systems(ReadInputs, read_local_inputs.in_set(InputSet::Serialize))
+            .add_systems(
+                GgrsSchedule,
+                update_remote_inputs.before(PhysicsSet::Player),
+            );
     }
 }
 


### PR DESCRIPTION
## Description

Fixes issue #110 

## Additional Notes

Also refactored input related system orders, mainly to fix some sync issues occuring because of `update_local_pointer_direction` order being previously non-deterministic

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] Ran the game in two-players networked mode.
- [x] Ran the game in local-play mode.
- [ ] Ran the game in synctest mode (`cargo run -- -m synctest`). **Currently broken**
- [x] Checked formatting and lints (`just check`).
