### PR TITLE
Fix/issue 108

### DIFF
--- a/src/ui/menu/home.rs
+++ b/src/ui/menu/home.rs
@@ -29,7 +29,9 @@ fn check_cmdline_args(
     mut next_screen: ResMut<NextState<Screen>>,
     mut next_gamestate: ResMut<NextState<GameState>>,
 ) {
-    if args.mode == GameMode::Synctest {
+    // Don't require going through menus if args are explicitely given
+    // TODO: Less cringe way of checking if players arg is given
+    if args.mode == GameMode::Synctest || args.players != 2 {
         next_screen.set(Screen::None);
         next_gamestate.set(GameState::MatchMaking);
     }

--- a/src/ui/menu/home.rs
+++ b/src/ui/menu/home.rs
@@ -30,6 +30,9 @@ fn check_cmdline_args(
     mut next_gamestate: ResMut<NextState<GameState>>,
 ) {
     // Don't require going through menus if args are explicitely given
+    if args.mode == GameMode::LocalPlay {
+        next_screen.set(Screen::SplitscreenSetup);
+    } else
     // TODO: Less cringe way of checking if players arg is given
     if args.mode == GameMode::Synctest || args.players != 2 {
         next_screen.set(Screen::None);

--- a/src/ui/menu/home.rs
+++ b/src/ui/menu/home.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy_cobweb_ui::prelude::*;
 
-use crate::ui::UIAssets;
+use crate::{Args, GameMode, GameState, ui::UIAssets};
 
 use super::Screen;
 
@@ -12,12 +12,26 @@ struct HomeMenu;
 pub struct HomeMenuPlugin;
 impl Plugin for HomeMenuPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(OnEnter(Screen::Home), spawn_menu)
-            .add_systems(
-                Update,
-                update_background_size.run_if(in_state(Screen::Home)),
-            )
-            .add_systems(OnExit(Screen::Home), despawn_menu);
+        app.add_systems(
+            OnEnter(Screen::Home),
+            (check_cmdline_args, spawn_menu).chain(),
+        )
+        .add_systems(
+            Update,
+            update_background_size.run_if(in_state(Screen::Home)),
+        )
+        .add_systems(OnExit(Screen::Home), despawn_menu);
+    }
+}
+
+fn check_cmdline_args(
+    args: Res<Args>,
+    mut next_screen: ResMut<NextState<Screen>>,
+    mut next_gamestate: ResMut<NextState<GameState>>,
+) {
+    if args.mode == GameMode::Synctest {
+        next_screen.set(Screen::None);
+        next_gamestate.set(GameState::MatchMaking);
     }
 }
 


### PR DESCRIPTION
## Description

Disables menus spawning when the given cmdline arguments are giving enough info for starting the game.

## Additional Notes

Fixes #108 

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] Ran the game in two-players networked mode.
- [x] Ran the game in local-play mode.
- [x] Ran the game in synctest mode (`cargo run -- -m synctest`).
- [x] Checked formatting and lints (`just check`).
