### PR TITLE
Fix #119

### DIFF
--- a/src/core/collision.rs
+++ b/src/core/collision.rs
@@ -30,11 +30,7 @@ where
 {
     fn build(&self, app: &mut App) {
         app.register_type::<CollisionShape>()
-            .register_required_components_with::<A, CollisionState<A, B>>(|| CollisionState {
-                closest: None,
-                collides: false,
-                _data: default(),
-            })
+            .register_required_components::<A, CollisionState<A, B>>()
             .add_systems(
                 GgrsSchedule,
                 check_collisions::<A, B>.in_set(PhysicsSet::Collision),
@@ -99,6 +95,20 @@ where
 {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<A, B> Default for CollisionState<A, B>
+where
+    A: Component,
+    B: Component,
+{
+    fn default() -> Self {
+        Self {
+            closest: None,
+            collides: false,
+            _data: default(),
+        }
     }
 }
 

--- a/src/entities/player/weapon/mod.rs
+++ b/src/entities/player/weapon/mod.rs
@@ -1,11 +1,13 @@
 use crate::{
     GameState,
     core::physics::{PhysicsSet, Position, Rotation, Velocity},
-    entities::projectile::{
-        Damage, DecayTimer, Projectile,
-        config::{BH_BULLET_DECAY_TIME, ProjectilesAssets, ProjectilesConfig},
+    entities::{
+        projectile::{
+            Damage, DecayTimer, Projectile,
+            config::{BH_BULLET_DECAY_TIME, ProjectilesAssets, ProjectilesConfig},
+        },
+        satellite::SatelliteSet,
     },
-    level::limit,
 };
 use bevy::{math::ops::cos, prelude::*};
 use bevy_ggrs::{AddRollbackCommandExtension, GgrsSchedule};
@@ -78,8 +80,8 @@ impl Plugin for WeaponPlugin {
                 GgrsSchedule,
                 (init_state, tick_weapon_timers, fire_weapon_system)
                     .chain()
-                    .in_set(PhysicsSet::Collision)
-                    .after(limit::handle_player_death),
+                    .in_set(PhysicsSet::Interaction)
+                    .before(SatelliteSet::Slingshot),
             );
     }
 }

--- a/src/entities/player/weapon/sfx.rs
+++ b/src/entities/player/weapon/sfx.rs
@@ -59,7 +59,7 @@ fn handle_weapon_events(
                 if let Some(instance) = audio_reload
                     .and_then(|audio_reload_handle| audio_instances.get_mut(&audio_reload_handle.0))
                 {
-                    instance.stop(AudioTween::default());
+                    instance.pause(AudioTween::default());
                 }
             }
         };

--- a/src/entities/satellite/mod.rs
+++ b/src/entities/satellite/mod.rs
@@ -35,9 +35,12 @@ pub struct SpawnSatelliteEvent {
 }
 
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
-enum SatelliteSet {
+pub enum SatelliteSet {
+    /// First
     Slingshot,
+    /// Second
     Bumper,
+    /// Last
     Grabber,
 }
 

--- a/src/level/limit.rs
+++ b/src/level/limit.rs
@@ -75,7 +75,7 @@ fn setup(
     commands.insert_resource(limit);
 }
 
-pub fn handle_player_death(
+fn handle_player_death(
     mut commands: Commands,
     mut death_events: EventReader<DeathEvent>,
     query: Query<&Arsenal, With<Player>>,

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -44,6 +44,7 @@ impl Plugin for NetworkPlugin {
             .rollback_component_with_clone::<gravity::Static>() // Mutated in grabber interactions
             .rollback_component_with_clone::<player::PlayerInputVelocity>()
             .rollback_component_with_clone::<player::Percentage>()
+            .rollback_component_with_clone::<player::Stunned>()
             .rollback_immutable_component_with_clone::<player::Weapon>()
             .rollback_component_with_clone::<weapon::WeaponMode>()
             .rollback_component_with_clone::<weapon::WeaponState>()


### PR DESCRIPTION
## Description

Fixed #119 by introducing a new `player::Stunned` component which makes the player bounce when landing on a planet. This component is inserted when a player is hit and cleared on the next frame. That is a temporary way of using that new component that makes hits received on a planet trigger the bounce logic.

## Additional Notes

Refactored a bit weapon systems scheduling and ordering. Fixed an issue where reload sounds would not resume when re-equipped

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] Ran the game in two-players networked mode.
- [x] Ran the game in local-play mode.
- [x] Ran the game in synctest mode (`cargo run -- -m synctest`).
- [x] Checked formatting and lints (`just check`).
